### PR TITLE
fix(magma): add timeout and validation to get_fast_fee()

### DIFF
--- a/Magma/magma_sale_process.py
+++ b/Magma/magma_sale_process.py
@@ -655,14 +655,25 @@ def execute_lnd_command(
         return None, err_msg
 
 
+# Bound for the mempool.space fee lookup. Without an explicit timeout, requests
+# blocks indefinitely on an unresponsive endpoint.
+MEMPOOL_API_TIMEOUT_SECONDS = 15
+
+
 def get_fast_fee():
-    response = requests.get(MEMPOOL_FEES_API_URL)
-    data = response.json()
-    if data:
-        fast_fee = data["fastestFee"]
-        return fast_fee
-    else:
+    try:
+        response = requests.get(MEMPOOL_FEES_API_URL, timeout=MEMPOOL_API_TIMEOUT_SECONDS)
+        response.raise_for_status()
+        fast_fee = response.json().get("fastestFee")
+    except Exception as e:
+        logging.exception(f"Failed to fetch fee rate from mempool API: {e}")
         return None
+
+    if isinstance(fast_fee, bool) or not isinstance(fast_fee, (int, float)) or fast_fee <= 0:
+        logging.error(f"Invalid fastestFee from mempool API: {fast_fee!r}")
+        return None
+
+    return fast_fee
 
 
 def get_node_connection_details(peer_pubkey: str) -> list[dict]:


### PR DESCRIPTION
## Problem

`get_fast_fee()` is the only `requests` call in `magma_sale_process.py` without a `timeout=` — the other six call sites set one. `requests` applies no default timeout, so against an unresponsive endpoint (a dropped connection rather than a refused one) it blocks indefinitely.

The consequence extends past the function. The main loop is:

```python
while True:
    schedule.run_pending()
    time.sleep(1)
```

`schedule.run_pending()` executes due jobs synchronously in the calling thread, so a blocked `get_fast_fee()` inside `execute_bot_behavior` stops the loop and every other scheduled job with it — including `check_pending_confirmations_timeouts`, which is what keeps auto-approval responsive.

It is also hard to notice: the process never exits, so a `Restart=always` systemd unit never fires, and the Telegram poller runs in its own daemon thread, so the bot keeps answering commands while the scheduler is stopped.

Two smaller issues in the same function: there is no `raise_for_status()`, so an HTML error page reaches `.json()`; and `data["fastestFee"]` raises `KeyError` if the response shape changes.

## Change

- `timeout=MEMPOOL_API_TIMEOUT_SECONDS` (15s)
- `raise_for_status()`
- `.get("fastestFee")` instead of direct indexing
- reject non-numeric, boolean, zero and negative values
- fail closed: return `None` on any failure

## Caller impact

None. `open_channel()` already treats `None` as "Fee rate could not be determined" and returns before opening a channel, so the abort path already exists and is unchanged.
